### PR TITLE
FIX RTM RETRY AND RECONNECT LOGIC

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -25,8 +25,8 @@ module.exports = function(botkit, config) {
     var retryBackoff = null;
 
     // config.retry, can be Infinity too
-    var retryEnabled = bot.config.retry ? true : false;
-    var maxRetry = isNaN(bot.config.retry) || bot.config.retry <= 0 ? 3 : bot.config.retry;
+    var retryEnabled = botkit.config.retry ? true : false;
+    var maxRetry = isNaN(botkit.config.retry) || botkit.config.retry <= 0 ? 3 : botkit.config.retry;
 
     /**
      * Set up API to send incoming webhook


### PR DESCRIPTION
Existing Botkit slackbot reconnect logic is failing. The retry attributes are passed along with the botkit object but slackbot_worker.js is looking for them in the bot object. Because these attributes do not exist the retry will always fail. There have been several issues opened against this problem and custom code has been written to try to manage the scenario with there is an RTM disconnect and the bot essentially dies for that team because it cannot reconnect.

This fix points to the botkit object in slack_worker.js which then allows the retry logic to work as planned. Since making this change the bot will automatically reconnect and use the reconnect attributes that are used when the controller is initiated.