### PR TITLE
Emit the original RTM message events in addition to Botkit's.

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -575,6 +575,7 @@ function Slackbot(configuration) {
 
             slack_botkit.debug('DEFAULT SLACK MSG RECEIVED RESPONDER');
             if ('message' == message.type) {
+                slack_botkit.trigger('raw_message', [bot, message]);
 
                 if (message.text) {
                     message.text = message.text.trim();

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -200,6 +200,17 @@ controller.on('channel_leave',function(bot,message) {
 })
 ```
 
+To receive the raw RTM events that are of type `message`, you can listen for the `raw_message` event. This gets emitted in addition to Botkit's own events described below. This is useful if you want to collect all message events for a channel, or if you want to do your own event processing.
+
+```javascript
+controller.on('raw_message',function(bot,message) {
+
+  // message format matches this:
+  // https://api.slack.com/events/message
+
+})
+```
+
 Finally, Botkit throws a handful of its own events!
 Events related to the general operation of bots are below.
 When used in conjunction with the Slack Button, Botkit also fires


### PR DESCRIPTION
Currently, Botkit consumes Slack RTM events of type `message` and then transposes them into Botkit specific events, which it emits. However, this is problematic when a developer requires all events, or wants to do their own transpositions. This change emits both the original RTM event and the Botkit transposition.